### PR TITLE
Now supporting REST endpoints where we can't verify up to date nodes …

### DIFF
--- a/CosmosProposalBot/Program.cs
+++ b/CosmosProposalBot/Program.cs
@@ -2,6 +2,7 @@
 using CosmosProposalBot.Configuration;
 using CosmosProposalBot.Data;
 using CosmosProposalBot.Modules;
+using CosmosProposalBot.Services;
 using CosmosProposalBot.Util;
 using Discord;
 using Discord.Interactions;

--- a/CosmosProposalBot/Services/ProposalCheckService.cs
+++ b/CosmosProposalBot/Services/ProposalCheckService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
-namespace CosmosProposalBot;
+namespace CosmosProposalBot.Services;
 
 
 

--- a/CosmosProposalBot/Services/ProposalCheckService.cs
+++ b/CosmosProposalBot/Services/ProposalCheckService.cs
@@ -100,72 +100,13 @@ public class ProposalCheckService : IHostedService
                     _logger.LogInformation("Updating proposals for chain {ChainName}", chain.Name);
                     
                     var eventBroadcaster = innerScope.ServiceProvider.GetRequiredService<EventBroadcaster>();
-                    foreach( var restEndpoint in chain.Endpoints.Where( e => e.Type == EndpointType.Rest ) )
+                    var updatedFromVerifiedUpToDateNode = await UpdateProps(chain, innerDbContext, httpClientFactory, eventBroadcaster, token);
+                    if (!updatedFromVerifiedUpToDateNode)
                     {
-                        try
-                        {
-                            var restHttpClient = httpClientFactory.CreateClient( $"{restEndpoint.Provider}-rest" );
-                            var latestBlockInfoJson = await restHttpClient.GetStringAsync( $"{restEndpoint.Url}/cosmos/base/tendermint/v1beta1/blocks/latest", token );
-                            var latestBlockInfo = JsonConvert.DeserializeObject<BlockInfoResult>( latestBlockInfoJson );
-                            
-                            if( latestBlockInfo?.Block?.Header?.Time < DateTime.UtcNow.AddMinutes( -5 ) )
-                            {
-                                _logger.LogWarning($"Block is too old ({latestBlockInfo?.Block?.Header?.Time} < UTC NOW - 5min). Skipping provider REST {restEndpoint.Provider}..");
-                                continue;
-                            }
-                            
-                            var proposalInfoJson = await restHttpClient.GetStringAsync( $"{restEndpoint.Url}/cosmos/gov/v1beta1/proposals?pagination.limit=25&pagination.reverse=true&pagination.key=", token );
-                            var propInfos = JsonConvert.DeserializeObject<ProposalInfoResponse>( proposalInfoJson );
-
-                            foreach( var prop in propInfos.Proposals )
-                            {
-                                var existingProposal = chain.Proposals.FirstOrDefault( p => p.ProposalId == prop.Id );
-                                if( existingProposal != null )
-                                {
-                                    if( existingProposal.Status != prop.Status )
-                                    {
-                                        _logger.LogInformation("Updating status of proposal {ProposalId} on chain {ChainName} from {OldStatus} to {NewStatus}", prop.Id, chain.Name, existingProposal.Status, prop.Status );
-                                        await eventBroadcaster.BroadcastStatusChangeAsync( existingProposal, prop.Status );
-                                        existingProposal.Status = prop.Status;
-                                        existingProposal.SubmitTime = DateTime.Parse(prop.SubmitTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime();
-                                        existingProposal.DepositEndTime = DateTime.Parse(prop.DepositEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime();
-                                        existingProposal.VotingStartTime = DateTime.Parse(prop.VotingStartTIme, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime();
-                                        existingProposal.VotingEndTime = DateTime.Parse(prop.VotingEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime();
-                                    }
-                                }
-                                else
-                                {
-                                    _logger.LogInformation("Found new proposal {ProposalId} on chain {ChainName}", prop.Id, chain.Name);
-                                    var newProp = new Proposal
-                                    {
-                                        Chain = chain,
-                                        Title = prop.Content.Title,
-                                        Description = prop.Content.Description,
-                                        ProposalId = prop.Id,
-                                        ProposalType = prop.Content.Type,
-                                        SubmitTime = DateTime.Parse(prop.SubmitTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime(),
-                                        DepositEndTime = DateTime.Parse(prop.DepositEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime(),
-                                        VotingStartTime = DateTime.Parse(prop.VotingStartTIme, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime(),
-                                        VotingEndTime = DateTime.Parse(prop.VotingEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal).ToUniversalTime()
-                                    };
-                                    await eventBroadcaster.BroadcastStatusChangeAsync( newProp, prop.Status );
-                                    newProp.Status = prop.Status;
-                                    
-                                    chain.Proposals.Add( newProp);
-                                    innerDbContext.Proposals.Add( newProp );
-                                    
-                                }
-                            }
-                            
-                            await innerDbContext.SaveChangesAsync( token );
-                            break;
-                        }
-                        catch( Exception e )
-                        {
-                            _logger.LogDebug($"Failed in looking up block info for chain {chain.Name}: {e.Message}. Will try with the next RPC endpoint if there is one...");
-                        }
-                    }
-                
+                        _logger.LogWarning("Could not update proposals for chain {ChainName} from verified up to date node, trying from any node", chain.Name);
+                        await UpdateProps(chain, innerDbContext, httpClientFactory, eventBroadcaster, token, true);
+                    } 
+                    
                     _logger.LogTrace($"Finished with chain {chain.Name}");
                 }
                 catch( Exception e )
@@ -175,6 +116,92 @@ public class ProposalCheckService : IHostedService
             } );
 
         _logger.LogDebug($"Finished with all chains");
+    }
+
+    private async Task<bool> UpdateProps( 
+        Chain chain, 
+        CopsDbContext innerDbContext, 
+        IHttpClientFactory httpClientFactory, 
+        EventBroadcaster eventBroadcaster, 
+        CancellationToken token,
+        bool skipVerifiedUpToDateNode = false )
+    {
+        foreach( var restEndpoint in chain.Endpoints.Where( e => e.Type == EndpointType.Rest ) )
+        {
+            try
+            {
+                var restHttpClient = httpClientFactory.CreateClient( $"{restEndpoint.Provider}-rest" );
+
+                if( !skipVerifiedUpToDateNode )
+                {
+                    var latestBlockInfoJson = await restHttpClient.GetStringAsync( $"{restEndpoint.Url}/cosmos/base/tendermint/v1beta1/blocks/latest", token );
+                    var latestBlockInfo = JsonConvert.DeserializeObject<BlockInfoResult>( latestBlockInfoJson );
+
+                    if( latestBlockInfo?.Block?.Header?.Time < DateTime.UtcNow.AddMinutes( -5 ) )
+                    {
+                        _logger.LogWarning( $"Block is too old ({latestBlockInfo?.Block?.Header?.Time} < UTC NOW - 5min). Skipping provider REST {restEndpoint.Provider}.." );
+                        continue;
+                    }
+                }
+
+                var proposalInfoJson =
+                    await restHttpClient.GetStringAsync( $"{restEndpoint.Url}/cosmos/gov/v1beta1/proposals?pagination.limit=25&pagination.reverse=true&pagination.key=", token );
+                var propInfos = JsonConvert.DeserializeObject<ProposalInfoResponse>( proposalInfoJson );
+
+                foreach( var prop in propInfos.Proposals )
+                {
+                    var existingProposal = chain.Proposals.FirstOrDefault( p => p.ProposalId == prop.Id );
+                    if( existingProposal != null )
+                    {
+                        if( existingProposal.Status != prop.Status )
+                        {
+                            _logger.LogInformation( "Updating status of proposal {ProposalId} on chain {ChainName} from {OldStatus} to {NewStatus}", prop.Id, chain.Name,
+                                existingProposal.Status, prop.Status );
+                            await eventBroadcaster.BroadcastStatusChangeAsync( existingProposal, prop.Status );
+                            existingProposal.Status = prop.Status;
+                            existingProposal.SubmitTime = DateTime.Parse( prop.SubmitTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime();
+                            existingProposal.DepositEndTime =
+                                DateTime.Parse( prop.DepositEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime();
+                            existingProposal.VotingStartTime =
+                                DateTime.Parse( prop.VotingStartTIme, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime();
+                            existingProposal.VotingEndTime =
+                                DateTime.Parse( prop.VotingEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime();
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogInformation( "Found new proposal {ProposalId} on chain {ChainName}", prop.Id, chain.Name );
+                        var newProp = new Proposal
+                        {
+                            Chain = chain,
+                            Title = prop.Content.Title,
+                            Description = prop.Content.Description,
+                            ProposalId = prop.Id,
+                            ProposalType = prop.Content.Type,
+                            SubmitTime = DateTime.Parse( prop.SubmitTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime(),
+                            DepositEndTime = DateTime.Parse( prop.DepositEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime(),
+                            VotingStartTime = DateTime.Parse( prop.VotingStartTIme, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime(),
+                            VotingEndTime = DateTime.Parse( prop.VotingEndTime, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal ).ToUniversalTime()
+                        };
+                        await eventBroadcaster.BroadcastStatusChangeAsync( newProp, prop.Status );
+                        newProp.Status = prop.Status;
+
+                        chain.Proposals.Add( newProp );
+                        innerDbContext.Proposals.Add( newProp );
+
+                    }
+                }
+
+                await innerDbContext.SaveChangesAsync( token );
+                return true;
+            }
+            catch( Exception e )
+            {
+                _logger.LogDebug( $"Failed in looking up block info for chain {chain.Name}: {e.Message}. Will try with the next RPC endpoint if there is one..." );
+            }
+        }
+
+        return false;
     }
 
     public async Task StopAsync( CancellationToken cancellationToken )

--- a/CosmosProposalBot/Util/ImageFetcher.cs
+++ b/CosmosProposalBot/Util/ImageFetcher.cs
@@ -32,7 +32,7 @@ public class ImageFetcher
         }
     }
 
-    public async Task<string?> FetchImage( string sourceUrl, string chainName )
+    public async Task<string?> FetchImage( string? sourceUrl, string chainName )
     {
         if( !_isEnabled )
         {


### PR DESCRIPTION
…via tendermint queries (e.g the case with gravity bridge). We can't fall back on RPC as that might be a different node and could falsly report up to date, which isn't better. $11h